### PR TITLE
Adding link to GitHub workflow details to help describe setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,4 +97,4 @@ Utility for handling backups for a self-hosted website.
 
 ### Github Actions Setup
 
-@todo 
+See the entry for the [`robo-scheduled-backups` workflow](https://github.com/daggerhartlab/devops/blob/main/github/workflows/robo-scheduled-backups.md) in our devops repo.


### PR DESCRIPTION
Provides a link to the devops repo to help describe GitHub Action/Workflow integration which was previously marked as `@todo`